### PR TITLE
Add command-line interface

### DIFF
--- a/wordsearch/__init__.py
+++ b/wordsearch/__init__.py
@@ -14,6 +14,7 @@ import argparse
 
 __version__ = '0.1.0'
 
+
 def build_argument_parser():
     """Constructs and configures an :obj:`argparse.ArgumentParser`.
 
@@ -24,12 +25,11 @@ def build_argument_parser():
         A configured instance of :obj:`argparse.ArgumentParser`.
     """
     argument_parser = argparse.ArgumentParser(
-        prog='wordsearch',
-        description='Solves word search puzzles.')
-    argument_parser.add_argument(
-        'puzzle_file',
-        help='The input puzzle file to solve.')
+        prog='wordsearch', description='Solves word search puzzles.')
+    argument_parser.add_argument('puzzle_file',
+                                 help='The input puzzle file to solve.')
     return argument_parser
+
 
 def main(argv=None):
     """The main entry point of the program.
@@ -40,6 +40,7 @@ def main(argv=None):
     argument_parser = build_argument_parser()
     arguments = argument_parser.parse_args()
     print('Hello, world!')
+
 
 if __name__ == '__main__':
     main()

--- a/wordsearch/test/test_main.py
+++ b/wordsearch/test/test_main.py
@@ -3,6 +3,7 @@ import argparse
 import subprocess
 import wordsearch
 
+
 class ArgumentParserTest(unittest.TestCase):
 
     def setup_method(self, method):
@@ -25,12 +26,12 @@ class ArgumentParserTest(unittest.TestCase):
         assert 'puzzle_file' in arguments
         assert arguments.puzzle_file == self.sample_puzzle
 
+
 class HelpAndUsageTest(unittest.TestCase):
 
     def setup_method(self, method):
-        self.process = subprocess.run(
-            'python -m wordsearch -h'.split(),
-            stdout=subprocess.PIPE)
+        self.process = subprocess.run('python -m wordsearch -h'.split(),
+                                      stdout=subprocess.PIPE)
         self.stdout = self.process.stdout.decode()
 
     def test_passing_the_help_flag_prints_the_program_usage(self):


### PR DESCRIPTION
This uses python's built-in argparse module to construct an argument parser. This offers a robust means of parsing command-line arguments (rather than doing it manually by accessing sys.argv directly). 

The parser is configured with a program name, description, and set up so that it accepts a single positional argument for the input file.

Closes: #9 