### PR TITLE
Integrate puzzle class with main

### DIFF
--- a/wordsearch/__init__.py
+++ b/wordsearch/__init__.py
@@ -16,12 +16,14 @@ from wordsearch.solver import Puzzle
 
 __version__ = '0.1.0'
 
+
 def format_results(results, words):
     strings = []
     for word in words:
-        positions = ','.join(['(%s,%s)' % (x,y) for y,x in results[word]])
+        positions = ','.join(['(%s,%s)' % (x, y) for y, x in results[word]])
         strings.append('%s: %s' % (word, positions))
     return '\n'.join(strings)
+
 
 def parse_puzzle(puzzle_file):
     """Parses a puzzle file, producing a list of words and puzzle board.
@@ -104,6 +106,7 @@ def main():
     arguments.puzzle_file.close()
     puzzle = Puzzle(board)
     print(format_results(puzzle.find_all(words), words))
+
 
 if __name__ == '__main__':
     main()

--- a/wordsearch/test/test_main.py
+++ b/wordsearch/test/test_main.py
@@ -153,6 +153,7 @@ class OutputFormatTest(unittest.TestCase):
         }
         words = PILLAR_SAMPLE_WORD_LIST
         formatted_text = wordsearch.format_results(results, words)
+        # yapf: disable
         expected = '\n'.join([
             'BONES: (0,6),(0,7),(0,8),(0,9),(0,10)',
             'KHAN: (5,9),(5,8),(5,7),(5,6)',
@@ -160,7 +161,9 @@ class OutputFormatTest(unittest.TestCase):
             'SCOTTY: (0,5),(1,5),(2,5),(3,5),(4,5),(5,5)',
             'SPOCK: (2,1),(3,2),(4,3),(5,4),(6,5)',
             'SULU: (3,3),(2,2),(1,1),(0,0)',
-            'UHURA: (4,0),(3,1),(2,2),(1,3),(0,4)'])
+            'UHURA: (4,0),(3,1),(2,2),(1,3),(0,4)'
+        ])
+        # yapf: enable
         assert expected == formatted_text
 
 
@@ -189,6 +192,7 @@ class SolverIntegrationTest(unittest.TestCase):
         }
         assert expected == actual
 
+
 class WordsearchEndToEndTest(unittest.TestCase):
     """Tests the entire application end-to-end."""
 
@@ -200,6 +204,7 @@ class WordsearchEndToEndTest(unittest.TestCase):
         self.stdout = self.process.stdout.decode()
 
     def test_wordsearch_solves_the_input_puzzle_file(self):
+        # yapf: disable
         expected = '\n'.join([
             'BONES: (0,6),(0,7),(0,8),(0,9),(0,10)',
             'KHAN: (5,9),(5,8),(5,7),(5,6)',
@@ -207,5 +212,7 @@ class WordsearchEndToEndTest(unittest.TestCase):
             'SCOTTY: (0,5),(1,5),(2,5),(3,5),(4,5),(5,5)',
             'SPOCK: (2,1),(3,2),(4,3),(5,4),(6,5)',
             'SULU: (3,3),(2,2),(1,1),(0,0)',
-            'UHURA: (4,0),(3,1),(2,2),(1,3),(0,4)'])
+            'UHURA: (4,0),(3,1),(2,2),(1,3),(0,4)'
+        ])
+        # yapf: enable
         assert expected in self.stdout


### PR DESCRIPTION
This patch bring the application to full function, however, there is missing docstring that will need to be added as part of another issue.

The tests added as part of this pull request cover both the integration between the main application and the Puzzle class, but also test the application from the user's point of view by running it on the command-line with a file path argument to a puzzle file.

Closes: #1, #2, #3, #4, #5, #21